### PR TITLE
Log errors instead of emitting as an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = function(options) {
         });
 
         // Pass content of the file as STDIN to Code Sniffer
-        phpcs.stdin.write(file.contents);
-        phpcs.stdin.end();
+        //phpcs.stdin.write(file.contents);
+        //phpcs.stdin.end();
     });
 }


### PR DESCRIPTION
Firstly, thank you for making this plugin, it's great that someone else is also trying to do this.

If the plugin emits the file as an error, then gulp-phpcs will stop at the first error. Currently this is just logging it with `gutil.log` which could be replaced with other reporting tools.
