### PR TITLE
Add sniff code option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The encoding of the files being checked.
 
 This option is equivalent to Code Sniffer `--encoding="<encoding>"` option.
 
-#### options.sniffCodes
+#### options.showSniffCode
 
 Type: `Boolean`
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ var buildCommand = function(opt) {
         command += ' --encoding="' + opt.encoding + '"';
     }
 
-    if (opt.hasOwnProperty('sniffCodes')) {
+    if (opt.hasOwnProperty('showSniffCode')) {
         command += ' -s';
     }
 


### PR DESCRIPTION
This PR adds the `-s` option from phpcs which shows the sniff codes in the report. Thanks again for this package :+1: 
