### PR TITLE
support for the built-in phpcs reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ This option is equivalent to Code Sniffer `--colors` option.
 
 **Warning**: This options is only compatible with 2.x branch of Code Sniffer.
 
+#### options.reports
+
+Type: `Array`
+
+Generate reports in different formats with the results.
+
+Supports all of the PHPCS report types.
+
+```
+reports: [
+	'checkstyle': '/path/to/report/checkstyle-output.xml',
+	'gitblame': '/path/to/report/gitblame-output.txt'
+]
+```
+
 ### phpcs.reporter(name[, options])
 
 Loads one of the reporters that shipped with the plugin (see below).

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ This option is equivalent to Code Sniffer `--colors` option.
 
 #### options.reports
 
-Type: `Array`
+Type: `Object`
 
-Generate reports in different formats with the results.
+Generate reports from the built-in PHPCS reporting mechanism.
 
 Supports all of the PHPCS report types.
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var buildCommand = function(opts) {
         args.push('--colors');
     }
 
-    if (opts.hasOwnProperty('reports') && Array.isArray(opts.reports) && opts.reports.length !== 0) {
+    if (opts.hasOwnProperty('reports')) {
         for (var report in opts.reports) {
             args.push('--report-' + report + '=' + opts.reports[report] + '');
         }

--- a/index.js
+++ b/index.js
@@ -44,6 +44,12 @@ var buildCommand = function(opts) {
         args.push('--colors');
     }
 
+    if (opts.hasOwnProperty('reports') && Array.isArray(opts.reports) && opts.reports.length !== 0) {
+        for (var report in opts.reports) {
+            args.push('--report-' + report + '=' + opts.reports[report] + '');
+        }
+    }
+
     return {
         bin: opts.bin || 'phpcs',
         args: args


### PR DESCRIPTION
this PR adds another option to the plugin allowing for passing through parameters to generate the built-in reports that PHPCS offers.

to use it, try running
```
phpcs({
    bin: /path/to/phpcs,
    standard: 'PSR2',
    reports: {
        'checkstyle': '/path/to/output/report.xml',
        'gitblame': '/path/to/output/gitblame.txt'
    }
});
```

you can read more on this from the PHPCS docs https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting