### PR TITLE
Bind to phpcs close instead of exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ var runCodeSniffer = function(bin, args, file, callback) {
             callback(error);
         });
 
-        phpcs.on('exit', function(code) {
+        phpcs.on('close', function(code) {
             callback(null, code, stdout);
         });
 


### PR DESCRIPTION
It is possible that I/O isn't finished before exit is called.  See https://nodejs.org/api/child_process.html#child_process_event_close

This fixes a race condition where the error output is occasionally not reported, even though the exit code is.