### PR TITLE
PHPCS 3.0 will throw exit code 2 for fixable errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,9 @@ var buildCommand = function(opts) {
         args.push('--colors');
     }
 
+    // Finally specify the file is streamed on stdin.
+    args.push('-');
+
     return {
         bin: opts.bin || 'phpcs',
         args: args
@@ -202,8 +205,8 @@ var phpcsPlugin = function(options) {
                 return;
             }
 
-            if (exitCode > 1) {
-                // On codding style problems Code Sniffer should exists with "1" code.
+            if (exitCode > 2) {
+                // On codding style problems Code Sniffer should exists with "1" or "2" code.
                 // All other non-zero exit codes should be treated as Code Sniffer errors.
                 var phpcsError = new gutil.PluginError('gulp-phpcs', 'Execution of Code Sniffer Failed');
                 phpcsError.stdout = output;
@@ -218,7 +221,7 @@ var phpcsPlugin = function(options) {
                 output: ''
             };
 
-            if (exitCode === 1) {
+            if ((exitCode === 1) || (exitCode === 2)) {
                 // A codding style problem is found. Attache report to the file to allow
                 // reporters do their job.
                 report.error = true;

--- a/test/fixture/error
+++ b/test/fixture/error
@@ -4,5 +4,5 @@
 cat > /dev/null
 # It's just an arbitrary text.
 echo "This is a test error."
-# PHPCS uses exit-codes greater than 1 to report about real errors.
-exit 2
+# PHPCS uses exit-codes greater than 2 to report about real errors.
+exit 3

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -215,7 +215,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('');
+                expect(output).to.be.equal('-');
                 done();
             });
 
@@ -230,7 +230,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('--severity=0');
+                expect(output).to.be.equal('--severity=0 -');
                 done();
             });
 
@@ -245,7 +245,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('--warning-severity=1');
+                expect(output).to.be.equal('--warning-severity=1 -');
                 done();
             });
 
@@ -260,7 +260,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('--error-severity=2');
+                expect(output).to.be.equal('--error-severity=2 -');
                 done();
             });
 
@@ -275,7 +275,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('--standard=PSR2');
+                expect(output).to.be.equal('--standard=PSR2 -');
                 done();
             });
 
@@ -290,7 +290,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('--encoding=utf8');
+                expect(output).to.be.equal('--encoding=utf8 -');
                 done();
             });
 
@@ -305,7 +305,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('-s');
+                expect(output).to.be.equal('-s -');
                 done();
             });
 
@@ -320,7 +320,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('');
+                expect(output).to.be.equal('-');
                 done();
             });
 
@@ -336,10 +336,10 @@ describe('PHPCS', function() {
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
                 // Validate the option.
-                expect(output).to.match(/^--sniffs=/);
+                expect(output).to.match(/^--sniffs=([^\s]+) -$/);
                 // Validate used sniffs.
-                var usedSniffs = output.split('=')[1].split(',');
-                expect(usedSniffs).to.have.members(['foo', 'bar', 'baz']);
+                var usedSniffs = /^--sniffs=([^\s]+) -$/.exec(output);
+                expect(usedSniffs[1].split(',')).to.have.members(['foo', 'bar', 'baz']);
 
                 done();
             });
@@ -355,7 +355,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('');
+                expect(output).to.be.equal('-');
                 done();
             });
 
@@ -370,7 +370,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('');
+                expect(output).to.be.equal('-');
                 done();
             });
 
@@ -385,7 +385,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                var excludeArgs = /^--exclude=([^\s]+)$/.exec(output);
+                var excludeArgs = /^--exclude=([^\s]+) -$/.exec(output);
                 expect(excludeArgs).to.be.not.null;
                 expect(excludeArgs[1].split(',')).to.have.members(['foo', 'bar', 'baz']);
 
@@ -403,7 +403,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('');
+                expect(output).to.be.equal('-');
                 done();
             });
 
@@ -418,7 +418,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('');
+                expect(output).to.be.equal('-');
                 done();
             });
 
@@ -433,7 +433,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('--colors');
+                expect(output).to.be.equal('--colors -');
                 done();
             });
 
@@ -448,7 +448,7 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.be.equal('');
+                expect(output).to.be.equal('-');
                 done();
             });
 


### PR DESCRIPTION
See https://github.com/squizlabs/PHP_CodeSniffer/issues/930

Also adds command line argument `-` to specify files are streamed on stdin.

Fixes #34.