### PR TITLE
Add support and tests for the --report option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ The encoding of the files being checked.
 
 This option is equivalent to Code Sniffer `--encoding="<encoding>"` option.
 
+#### options.report
+
+Type: `String`
+
+The report type to generate.
+
+This option is equivalent to Code Sniffer `--report="<report>"` option.
+
 #### options.showSniffCode
 
 Type: `Boolean`

--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ var buildCommand = function(opts) {
         args.push('--encoding=' + opts.encoding);
     }
 
+    if (opts.hasOwnProperty('report')) {
+        args.push('--report=' + opts.report);
+    }
+
     if (opts.hasOwnProperty('showSniffCode') && opts.showSniffCode) {
         args.push('-s');
     }

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -321,6 +321,21 @@ describe('PHPCS', function() {
             plugin.write(fakeFile);
         });
 
+        it('should use passed in "report" option "as is"', function(done) {
+            var plugin = phpcs({
+                bin: './test/fixture/args',
+                report: 'summary'
+            });
+
+            plugin.on('data', function(file) {
+                var output = file.phpcsReport.output.trim();
+                expect(output).to.contain('--report=summary');
+                done();
+            });
+
+            plugin.write(fakeFile);
+        });
+
         it('should use "-s" flag if "showSniffCode" option is true', function(done) {
             var plugin = phpcs({
                 bin: './test/fixture/args',


### PR DESCRIPTION
Added support and tests for the `--report` option of `phpcs`. Here's some documentation about the possible options that `--report` allows: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting