### PR TITLE
Remove gulp-util package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: node_js
 sudo: false
 node_js:
-    - "0.10"
-    - "0.12"
-    - "iojs-v1"
-    - "iojs-v2"
-    - "iojs-v3"
-    - "4"
-    - "5"
     - "6"
     - "7"
+    - "8"
+    - "9"
+    - "10"
+    - "11"
+    - "12"
 script: "npm run jshint && npm run test"

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var util = require('util'),
     path = require('path'),
-    gutil = require('gulp-util'),
+    PluginError = require('plugin-error'),
     through = require('through2'),
     which = require('which'),
     spawn = require('child_process').spawn;
@@ -200,7 +200,7 @@ var phpcsPlugin = function(options) {
         }
 
         if (file.isStream()) {
-            stream.emit('error', new gutil.PluginError('gulp-phpcs', 'Streams are not supported'));
+            stream.emit('error', new PluginError('gulp-phpcs', 'Streams are not supported'));
             callback();
 
             return;
@@ -210,7 +210,7 @@ var phpcsPlugin = function(options) {
             if (runError) {
                 // Something is totally wrong. It seems that execution of Code Sniffer
                 // failed (not because of non-zero exit code of PHPCS).
-                stream.emit('error', new gutil.PluginError('gulp-phpcs', runError));
+                stream.emit('error', new PluginError('gulp-phpcs', runError));
                 callback();
 
                 return;
@@ -219,7 +219,7 @@ var phpcsPlugin = function(options) {
             if (exitCode > 2) {
                 // On codding style problems Code Sniffer should exists with "1" or "2" code.
                 // All other non-zero exit codes should be treated as Code Sniffer errors.
-                var phpcsError = new gutil.PluginError('gulp-phpcs', 'Execution of Code Sniffer Failed');
+                var phpcsError = new PluginError('gulp-phpcs', 'Execution of Code Sniffer Failed');
                 phpcsError.stdout = output;
                 stream.emit('error', phpcsError);
                 callback();

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "gulp-util": "^3.0.7",
     "through2": "^2.0.0",
     "chalk": "^1.1.1",
     "pluralize": "^1.2.1",
@@ -31,12 +30,14 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "is-windows": "^0.2.0",
+    "fancy-log": "^1.3.3",
     "file-exists": "^2.0.0",
+    "is-windows": "^0.2.0",
     "jshint": "^2.9.3",
     "mocha": "^3.0.2",
-    "mock-fs": "^3.11.0",
+    "mock-fs": "^4.9.0",
     "mock-require": "^1.3.0",
+    "plugin-error": "^1.0.1",
     "sinon": "^1.17.6",
     "vinyl": "^1.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "file-exists": "^2.0.0",
     "is-windows": "^0.2.0",
     "jshint": "^2.9.3",
-    "mocha": "^3.0.2",
+    "mocha": "^6.1.4",
     "mock-fs": "^4.9.0",
     "mock-require": "^1.3.0",
     "plugin-error": "^1.0.1",

--- a/reporters/fail.js
+++ b/reporters/fail.js
@@ -1,4 +1,4 @@
-var gutil = require('gulp-util'),
+var PluginError = require('plugin-error'),
     through = require('through2'),
     chalk = require('chalk');
 
@@ -32,7 +32,7 @@ module.exports = function(options) {
                     var errorMessage = 'PHP Code Sniffer failed' +
                         ' on ' + chalk.magenta(file.path);
 
-                    this.emit('error', new gutil.PluginError('gulp-phpcs', errorMessage));
+                    this.emit('error', new PluginError('gulp-phpcs', errorMessage));
                     callback();
 
                     return;
@@ -50,7 +50,7 @@ module.exports = function(options) {
             // We have to check "failOnFirst" flag to make sure we did not
             // throw the error before.
             if (phpcsError && !options.failOnFirst) {
-                this.emit('error', new gutil.PluginError(
+                this.emit('error', new PluginError(
                     'gulp-phpcs',
                     'PHP Code Sniffer failed on \n    ' + badFiles.join('\n    ')
                 ));

--- a/reporters/file.js
+++ b/reporters/file.js
@@ -1,6 +1,7 @@
 var fs = require('fs'),
     util = require('util'),
-    gutil = require('gulp-util'),
+    PluginError = require('plugin-error'),
+    log = require('fancy-log'),
     through = require('through2'),
     chalk = require('chalk'),
     pluralize = require('pluralize');
@@ -16,7 +17,7 @@ var fs = require('fs'),
 module.exports = function(options) {
     // Show the user an error message if no path is defined.
     if (!options || !options.path) {
-        throw new gutil.PluginError('gulp-phpcs', 'You have to specify a path for the file reporter!');
+        throw new PluginError('gulp-phpcs', 'You have to specify a path for the file reporter!');
     }
 
     var collectedErrors = [];
@@ -50,7 +51,7 @@ module.exports = function(options) {
             // Write the error output to the defined file
             fs.writeFile(options.path, report, function(err) {
                 if (err) {
-                    stream.emit('error', new gutil.PluginError('gulp-phpcs', err));
+                    stream.emit('error', new PluginError('gulp-phpcs', err));
                     callback();
 
                     return;
@@ -64,7 +65,7 @@ module.exports = function(options) {
                 );
 
                 // And output it.
-                gutil.log(message);
+                log.info(message);
 
                 callback();
             });

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -1,4 +1,4 @@
-var gutil = require('gulp-util'),
+var PluginError = require('plugin-error'),
     fs = require('fs');
 
 /**
@@ -13,11 +13,11 @@ var gutil = require('gulp-util'),
  */
 module.exports = function(name, options) {
     if (typeof name !== 'string') {
-        throw new gutil.PluginError('gulp-phpcs', 'Reporter name must be a string');
+        throw new PluginError('gulp-phpcs', 'Reporter name must be a string');
     }
 
     if (name === 'index') {
-        throw new gutil.PluginError('gulp-phpcs', 'Reporter cannot be named "index"');
+        throw new PluginError('gulp-phpcs', 'Reporter cannot be named "index"');
     }
 
     var fileName = './' + name + '.js',
@@ -29,7 +29,7 @@ module.exports = function(name, options) {
             throw error;
         }
 
-        throw new gutil.PluginError('gulp-phpcs', 'There is no reporter "' + name + '"');
+        throw new PluginError('gulp-phpcs', 'There is no reporter "' + name + '"');
     }
 
     return reporter;

--- a/reporters/log.js
+++ b/reporters/log.js
@@ -1,4 +1,4 @@
-var gutil = require('gulp-util'),
+var log = require('fancy-log'),
     through = require('through2'),
     chalk = require('chalk');
 
@@ -18,7 +18,7 @@ module.exports = function() {
             var message = 'PHP Code Sniffer found a ' + chalk.yellow('problem') +
                 ' in ' + chalk.magenta(file.path) + '\n' +
                 report.output.replace(/\n/g, '\n    ');
-            gutil.log(message);
+            log.info(message);
         }
 
         this.push(file);

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -1,7 +1,7 @@
 var path = require('path'),
     expect = require('chai').expect,
     File = require('vinyl'),
-    gutil = require('gulp-util'),
+    PluginError = require('plugin-error'),
     isWindows = require('is-windows'),
     phpcs = require('../../index.js');
 
@@ -20,7 +20,7 @@ describe('PHPCS', function() {
             });
 
             plugin.on('error', function(error) {
-                expect(error).to.be.an.instanceof(gutil.PluginError);
+                expect(error).to.be.an.instanceof(PluginError);
                 expect(error.message).to.contain('Cannot find');
                 expect(error.message).to.contain('./test/fixture/missed');
                 done();
@@ -203,7 +203,7 @@ describe('PHPCS', function() {
             });
 
             plugin.on('error', function(error) {
-                expect(error).to.be.an.instanceof(gutil.PluginError);
+                expect(error).to.be.an.instanceof(PluginError);
                 expect(error.message).to.be.equal('Execution of Code Sniffer Failed');
                 expect(error).to.have.property('stdout');
                 expect(error.stdout).to.contain('This is a test error.');

--- a/test/specs/reporters/fail.js
+++ b/test/specs/reporters/fail.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect,
     File = require('vinyl'),
-    gutil = require('gulp-util'),
+    PluginError = require('plugin-error'),
     failReporter = require('../../../reporters/fail'),
     through = require('through2');
 
@@ -34,7 +34,7 @@ describe('Fail reporter', function() {
         reporter.pipe(spy);
 
         reporter.on('error', function(error) {
-            expect(error).to.be.an.instanceof(gutil.PluginError);
+            expect(error).to.be.an.instanceof(PluginError);
             expect(error.message).to.contain('/src/bad_file.php');
             // Nothing should came through the stream.
             expect(spy.filesCount).to.equal(0);
@@ -66,7 +66,7 @@ describe('Fail reporter', function() {
         reporter.pipe(spy);
 
         reporter.on('error', function(error) {
-            expect(error).to.be.an.instanceof(gutil.PluginError);
+            expect(error).to.be.an.instanceof(PluginError);
             expect(error.message).to.contain('/src/bad_file.php');
             // Nothing should came through the stream.
             expect(spy.filesCount).to.equal(0);
@@ -98,7 +98,7 @@ describe('Fail reporter', function() {
         reporter.pipe(spy);
 
         reporter.on('error', function(error) {
-            expect(error).to.be.an.instanceof(gutil.PluginError);
+            expect(error).to.be.an.instanceof(PluginError);
             expect(error.message).to.contain('/src/bad_file.php');
             // All the files must pass through the pipe.
             expect(spy.filesCount).to.equal(2);
@@ -130,7 +130,7 @@ describe('Fail reporter', function() {
         reporter.pipe(spy);
 
         reporter.on('error', function(error) {
-            expect(error).to.be.an.instanceof(gutil.PluginError);
+            expect(error).to.be.an.instanceof(PluginError);
             expect(error.message).to.contain('/src/bad_file.php');
             expect(error.message).to.contain('/src/another_bad_file.php');
             expect(spy.filesCount).to.equal(2);

--- a/test/specs/reporters/file.js
+++ b/test/specs/reporters/file.js
@@ -1,5 +1,6 @@
 var fs = require('fs'),
-    gutil = require('gulp-util'),
+    PluginError = require('plugin-error'),
+    log = require('fancy-log'),
     mockFs = require('mock-fs'),
     expect = require('chai').expect,
     File = require('vinyl'),
@@ -63,15 +64,14 @@ describe('File reporter', function() {
             // Actually we have to replace gutil.log with a stub because its
             // current implementation uses "require" at run-time which will
             // fail after file system is mocked.
-            logStub = sinon.stub(gutil, 'log');
+            logStub = sinon.stub(log, 'info');
         });
 
         afterEach(function() {
             // Restore all mocks that are in use.
             mockFs.restore();
-            gutil.log.restore();
             // Clean up created instances.
-            logStub = null;
+            logStub.restore();
         });
 
         it('should write report for files with style problem', function(done) {
@@ -164,7 +164,7 @@ describe('File reporter', function() {
             var reporter = fileReporter({path: '/reports/locked.log'});
 
             reporter.on('error', function(error) {
-                expect(error).to.be.an.instanceof(gutil.PluginError);
+                expect(error).to.be.an.instanceof(PluginError);
                 done();
             });
 

--- a/test/specs/reporters/file.js
+++ b/test/specs/reporters/file.js
@@ -114,7 +114,7 @@ describe('File reporter', function() {
             reporter.end();
         });
 
-        it('should write nothing if a file has no style problems', function() {
+        it('should write nothing if a file has no style problems', function(done) {
             var reporter = fileReporter({path: '/reports/errors.log'});
 
             reporter.pipe(blackHole(function() {

--- a/test/specs/reporters/index.js
+++ b/test/specs/reporters/index.js
@@ -39,7 +39,7 @@ describe('Reporter loader', function() {
             reporterBuilder.reset();
         });
 
-	after(function() {
+    after(function() {
             mockRequire.stopAll();
         });
 

--- a/test/specs/reporters/log.js
+++ b/test/specs/reporters/log.js
@@ -1,21 +1,21 @@
 var expect = require('chai').expect,
     File = require('vinyl'),
     sinon = require('sinon'),
-    gutil = require('gulp-util'),
+    log = require('fancy-log'),
     logReporter = require('../../../reporters/log');
 
 describe('Log reporter', function() {
-    var reporter = null,
+    var reporter = null;
         logStub = null;
 
     beforeEach(function() {
         reporter = logReporter();
-        logStub = sinon.stub(gutil, 'log');
+        logStub = sinon.stub(log, 'info');
     });
 
     afterEach(function() {
         reporter = null;
-        gutil.log.restore();
+        logStub.restore();
     });
 
     it('should print PHPCS report for file with problems', function(done) {


### PR DESCRIPTION
This PR removes the deprecated gulp-util package. As a bonus it also updates the mocha package to fix the vulnerabilities found by npm-audit.