### PR TITLE
Spawn options api

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Ignore a list of paths
 
 This option is equivalent to Code Sniffer `--ignore` option.
 
+#### options.cwd
+
+Type: `String`
+
+Set an explicit current working directory from which the `phpcs` command should run.
+
 #### options.colors
 
 Type: `Boolean`

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -537,7 +537,22 @@ describe('PHPCS', function() {
 
             plugin.on('data', function(file) {
                 var output = file.phpcsReport.output.trim();
-                expect(output).to.not.contain('--collors');
+                expect(output).to.not.contain('--colors');
+                done();
+            });
+
+            plugin.write(fakeFile);
+        });
+
+        it('should run the command from a given directory if "cwd" option is passed', function(done) {
+            var plugin = phpcs({
+                bin: './test/fixture/args',
+                cwd: './'
+            });
+
+            plugin.on('data', function(file) {
+                var output = file.phpcsReport.output.trim();
+                expect(output).to.be.equal('-');
                 done();
             });
 


### PR DESCRIPTION
I was struggling with this plugin and couldn't figure out why my custom ruleset wasn't found in the composer directory, but I figured out that I just needed to set the command to run from a different directory. I was able to do this by passing an explicit cwd into `child_process.spawn` and I thought it might be helpful to expose this option in the API!